### PR TITLE
Update roadmap due to required refactoring and tech debt payback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,22 +15,22 @@ Please open an issue to track any initiative on the roadmap of Contour (Usually 
 The following table includes the current roadmap for Contour. If you have any questions or would like to contribute to Contour, please attend a [community meeting](https://projectcontour.io/community/) to discuss with our team. If you don't know where to start, we are always looking for contributors that will help us reduce technical, automation, and documentation debt.
 Please take the timelines & dates as proposals and goals. Priorities and requirements change based on community feedback, roadblocks encountered, community contributions, etc. If you depend on a specific item, we encourage you to attend community meetings to get updated status information, or help us deliver that feature by contributing to Contour.
 
-`Last Updated: June 2020`
+`Last Updated: August 2020`
 
 |Theme|Description|Timeline|
 |--|--|--|
-|Observability|Additional HTTPProxy Status information|August 2020|
-|Security|Authentication support for services backed by Contour|August 2020|
-|Compatibility|Implement Kubernetes Ingress V1 specification (requires v1.16)|August 2020|
-|Extensibility|Expose more Envoy configuration knobs|October 2020|
-|Performance|Rate limiting support|October 2020|
-|Observability|Support Access Log Service|October 2020|
-|General|Wildcard Path Matching|October 2020|
-|Deployment|Contour Helm Chart|October 2020|
+|Observability|Additional HTTPProxy Status information|October 2020|
+|Security|Authentication support for services backed by Contour|October 2020|
+|Compatibility|Implement Kubernetes Ingress V1 specification (requires v1.16)|October 2020|
+|Extensibility|Expose more Envoy configuration knobs|December 2020|
+|Performance|Rate limiting support|December 2020|
+|Observability|Support Access Log Service|December 2020|
+|General|Wildcard Path Matching|December 2020|
+|Deployment|Contour Helm Chart|December 2020|
 |Service APIs|Introduce support for upstream Service APIs|Long running (dependent on networking working group). Potentially an alpha release 3 months after Kubernetes v1.20|
-|New Use Case|UDP Support|December 2020|
-|Infrastructure|xDS v3 upgrade|December 2020|
-|Infrastructure|Incorporate Envoy go-control-plane to modernize xDS|December 2020|
-|General|Self Service Capabilities in Contour|March 2021|
+|New Use Case|UDP Support|February 2021|
+|Infrastructure|xDS v3 upgrade|February 2021|
+|Infrastructure|Incorporate Envoy go-control-plane to modernize xDS|February 2021|
+|General|Self Service Capabilities in Contour|May 2021|
 
 


### PR DESCRIPTION
The Contour maintainers have recently realised that some of our big
ticket items (like external authentication and upgrading from Envoy's
xDS v2 to v3 APIs) are very difficult with our current code structure,
with a couple of years of tech debt.

So we are taking some time to pay down some tech debt and refactor,
to build a base from which we can build all the extensibility that you,
our users are asking for.

We've been conservative with the roadmap updates here, these timeframes
allow for us to spend a bit more time now to save a lot of time later.

Signed-off-by: Nick Young <ynick@vmware.com>